### PR TITLE
Added alternative build that does not depends buildapp

### DIFF
--- a/make-asdf.sh
+++ b/make-asdf.sh
@@ -1,0 +1,1 @@
+sbcl --eval "(asdf:operate :build-op :site-generator)"

--- a/site-generator.asd
+++ b/site-generator.asd
@@ -1,5 +1,8 @@
 ;;;; site-generator.asd
 
+(defmethod asdf:perform ((o asdf:image-op) (c asdf:system))
+  (uiop:dump-image (asdf:output-file o c) :executable T :compression T))
+
 (asdf:defsystem #:site-generator
   :version "0.8.1"
   :serial t
@@ -19,7 +22,10 @@
   :in-order-to ((test-op (load-op :site-generator-test)))
   :perform (test-op :after (op c)
 		    (funcall (intern (string '#:run!) :it.bese.fiveam)
-			     :site-generator)))
+			     :site-generator))
+  :build-operation "asdf:program-op"
+  :build-pathname "../site-generator"
+  :entry-point "site-generator:main-asdf-build-wrapper")
 
 (asdf:defsystem :site-generator-test
   :author "Alex Charlton <alex.n.charlton@gmail.com>"

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -5,6 +5,7 @@
   (:use #:cl #:iterate #:let-plus #:alexandria #:cl-fad #:cl-ppcre #:bordeaux-threads #:cl-who #:local-time)
   (:import-from #:osicat
 		#:make-link #:delete-directory #:file-kind #:unmerge-pathnames)
+  (:export #:main-asdf-build-wrapper)
   (:shadowing-import-from #:cl-fad
 			  #:copy-file #:copy-stream))
 

--- a/src/site-generator.lisp
+++ b/src/site-generator.lisp
@@ -534,6 +534,7 @@ For more information, visit http://alex-charlton.com/projects/site-generator")
   (flag :short-name "v" :long-name "version"
 	:description "Print version number and exit."))
 
+
 (defun main (argv)
   "String -> nil
 Entry point. Perform the relevant action based on the command line options."
@@ -563,6 +564,9 @@ Entry point. Perform the relevant action based on the command line options."
 		 (run-test-server dir port) 
 		 (generate-site dir))))
     (error (e) (format t "Error: ~a~%" e))))
+
+(defun main-asdf-build-wrapper ()
+  (main ""))
 
 (defun get-site-dir ()
   "nil -> Pathname


### PR DESCRIPTION
I had problem using buildapp and instead ended up using the functions in asdf to build a binary instead.

This add a second make script that will just use sbcl to call asdf to do the build.