### PR TITLE
Remove osicat

### DIFF
--- a/site-generator.asd
+++ b/site-generator.asd
@@ -9,7 +9,7 @@
   :description "Describe site-generator here"
   :author "Alex Charlton <alex.n.charlton@gmail.com>"
   :license "BSD-2"
-  :depends-on (:let-plus :alexandria :iterate :hunchentoot :net.didierverna.clon :cl-ppcre :cl-fad :bordeaux-threads :osicat :cl-who :local-time)
+  :depends-on (:let-plus :alexandria :iterate :hunchentoot :net.didierverna.clon :cl-ppcre :cl-fad :bordeaux-threads :cl-who :local-time)
   :pathname "src"
   :components ((:file "package")
 	       (:file "utility")

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -4,8 +4,7 @@
   (:nicknames :sg)
   (:use #:cl #:iterate #:let-plus #:alexandria #:cl-fad #:cl-ppcre #:bordeaux-threads #:cl-who #:local-time)
   (:import-from #:osicat
-		#:make-link #:delete-directory #:file-kind #:unmerge-pathnames)
+		#:make-link #:file-kind #:unmerge-pathnames)
   (:export #:main-asdf-build-wrapper)
   (:shadowing-import-from #:cl-fad
 			  #:copy-file #:copy-stream))
-

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -3,8 +3,6 @@
 (defpackage #:site-generator
   (:nicknames :sg)
   (:use #:cl #:iterate #:let-plus #:alexandria #:cl-fad #:cl-ppcre #:bordeaux-threads #:cl-who #:local-time)
-  (:import-from #:osicat
-		#:make-link)
   (:export #:main-asdf-build-wrapper)
   (:shadowing-import-from #:cl-fad
 			  #:copy-file #:copy-stream))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -4,7 +4,7 @@
   (:nicknames :sg)
   (:use #:cl #:iterate #:let-plus #:alexandria #:cl-fad #:cl-ppcre #:bordeaux-threads #:cl-who #:local-time)
   (:import-from #:osicat
-		#:make-link #:unmerge-pathnames)
+		#:make-link)
   (:export #:main-asdf-build-wrapper)
   (:shadowing-import-from #:cl-fad
 			  #:copy-file #:copy-stream))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -4,7 +4,7 @@
   (:nicknames :sg)
   (:use #:cl #:iterate #:let-plus #:alexandria #:cl-fad #:cl-ppcre #:bordeaux-threads #:cl-who #:local-time)
   (:import-from #:osicat
-		#:make-link #:file-kind #:unmerge-pathnames)
+		#:make-link #:unmerge-pathnames)
   (:export #:main-asdf-build-wrapper)
   (:shadowing-import-from #:cl-fad
 			  #:copy-file #:copy-stream))

--- a/src/site-generator.lisp
+++ b/src/site-generator.lisp
@@ -358,15 +358,18 @@ Delete the files in the list of old pages contained in ENTRY."
 (defun remove-empty-directories (dir)
   "Pathname -> nil
 Recurs depth first through a directory tree, deleting all directories that do not contain any files."
+
+  ;; guesing this whole thing could be replaced with call to
+  ;; delete-directory-tree from uiop instead of doing this walking of
+  ;; the directory structure manually  
   (iter (for file in (list-directory dir :follow-symlinks nil))
 	(when (and (directory-pathname-p file)
 		   (not (equal (parent-directory file) "static")))
 	  (remove-empty-directories file)))
   (handler-case (unless (list-directory dir)
-		  (delete-directory dir)
+		  (uiop:delete-empty-directory dir)
 		  (print-message "Removing unused directory: ~a"
-				 (directory-minus dir *site-dir*)))
-    (osicat-posix:enotdir () nil)))
+				 (directory-minus dir *site-dir*)))))
 
 (defun get-file-slugs (content-file)
   "Pathname -> Plist

--- a/src/test-server.lisp
+++ b/src/test-server.lisp
@@ -42,12 +42,14 @@ Watch the site for changes and update it when they occur."
 (defmethod hunchentoot:acceptor-dispatch-request ((acceptor acceptor) request)
   "Serve up a static file, with 'index.html' being served when a directory is being requested."
   (let* ((uri (subseq (hunchentoot:script-name request) 1))
-	(file (merge-pathnames uri *site-dir*)))
-    (when (file-exists-p file)
+	 (file (merge-pathnames uri *site-dir*)))
+    ;; bind pathspec so we later can't test if it is a directory
+    (when-let (pathspec (file-exists-p file))
       (hunchentoot:handle-static-file
-       (if (eq (file-kind file) :directory)
-	   (merge-pathnames "index.html" (pathname-as-directory file))
-	   file)))))
+       ;; directories does not have a name part
+       (if (pathname-name pathspec)
+	   file
+	   (merge-pathnames "index.html" (pathname-as-directory file)))))))
 
 (defun start-server (port)
   "Integer -> nil


### PR DESCRIPTION
The goal of this pull request and the another one called add-ci is to be able to get an binary that can be built on one machine and deployed on another machine without having to bring osicat.so library along.

3 functions from osicat library was in use, two of them was easy to replace with things uiop library that is part of asdf. the last on called make-link was the hard one and i resorted to calling the ln command in a subprocess..